### PR TITLE
feat: ファイル名生成機能実装 (filename) (#20)

### DIFF
--- a/src/lib/filename.test.ts
+++ b/src/lib/filename.test.ts
@@ -1,0 +1,296 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  sanitize,
+  guessExtension,
+  deconflict,
+  makeFilename,
+  getPresetTemplate,
+  PRESET_TEMPLATES,
+} from './filename'
+import type { ImageSnapshot } from '../shared/types'
+
+describe('sanitize', () => {
+  it('禁止文字を"-"に置換する', () => {
+    const input = 'file<>:"/\\|?*name'
+    const result = sanitize(input)
+    expect(result).toBe('file-name')
+  })
+
+  it('制御文字を"-"に置換する', () => {
+    const input = 'file\x00\x1Fname'
+    const result = sanitize(input)
+    expect(result).toBe('file-name')
+  })
+
+  it('連続する空白を単一ハイフンに置換する', () => {
+    const input = 'file    name'
+    const result = sanitize(input)
+    expect(result).toBe('file-name')
+  })
+
+  it('連続するハイフンを単一ハイフンに置換する', () => {
+    const input = 'file---name'
+    const result = sanitize(input)
+    expect(result).toBe('file-name')
+  })
+
+  it('先頭・末尾のハイフンを削除する', () => {
+    const input = '-filename-'
+    const result = sanitize(input)
+    expect(result).toBe('filename')
+  })
+
+  it('50文字を超える場合は切り詰める', () => {
+    const input = 'a'.repeat(60)
+    const result = sanitize(input)
+    expect(result.length).toBe(50)
+  })
+
+  it('空文字の場合はデフォルト名を返す', () => {
+    const input = ''
+    const result = sanitize(input)
+    expect(result).toBe('image')
+  })
+
+  it('禁止文字のみの入力でもデフォルト名を返す', () => {
+    const input = '<>:"/\\|?*'
+    const result = sanitize(input)
+    expect(result).toBe('image')
+  })
+})
+
+describe('guessExtension', () => {
+  it('data URLからMIMEタイプを読み取る: image/jpeg', () => {
+    const url = 'data:image/jpeg;base64,/9j/4AAQ...'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+
+  it('data URLからMIMEタイプを読み取る: image/png', () => {
+    const url = 'data:image/png;base64,iVBORw0KGgo...'
+    const result = guessExtension(url)
+    expect(result).toBe('png')
+  })
+
+  it('data URLからMIMEタイプを読み取る: image/webp', () => {
+    const url = 'data:image/webp;base64,UklGR...'
+    const result = guessExtension(url)
+    expect(result).toBe('webp')
+  })
+
+  it('通常URLからパスの拡張子を読み取る: .jpg', () => {
+    const url = 'https://example.com/images/photo.jpg'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+
+  it('通常URLからパスの拡張子を読み取る: .png', () => {
+    const url = 'https://example.com/images/photo.png'
+    const result = guessExtension(url)
+    expect(result).toBe('png')
+  })
+
+  it('通常URLからパスの拡張子を読み取る: .gif', () => {
+    const url = 'https://example.com/images/photo.gif'
+    const result = guessExtension(url)
+    expect(result).toBe('gif')
+  })
+
+  it('.jpegを.jpgに正規化する', () => {
+    const url = 'https://example.com/images/photo.jpeg'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+
+  it('拡張子がない場合はデフォルトで.jpgを返す', () => {
+    const url = 'https://example.com/images/photo'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+
+  it('不明な拡張子の場合はデフォルトで.jpgを返す', () => {
+    const url = 'https://example.com/images/photo.txt'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+
+  it('無効なURLの場合はデフォルトで.jpgを返す', () => {
+    const url = 'not-a-valid-url'
+    const result = guessExtension(url)
+    expect(result).toBe('jpg')
+  })
+})
+
+describe('deconflict', () => {
+  it('衝突しない場合はそのまま返す', () => {
+    const existing = new Set(['file1.jpg', 'file2.jpg'])
+    const result = deconflict('file3.jpg', existing)
+    expect(result).toBe('file3.jpg')
+  })
+
+  it('衝突する場合は-1を付与する', () => {
+    const existing = new Set(['image.jpg'])
+    const result = deconflict('image.jpg', existing)
+    expect(result).toBe('image-1.jpg')
+  })
+
+  it('複数回衝突する場合はカウンターを増やす', () => {
+    const existing = new Set(['image.jpg', 'image-1.jpg', 'image-2.jpg'])
+    const result = deconflict('image.jpg', existing)
+    expect(result).toBe('image-3.jpg')
+  })
+
+  it('拡張子がない場合も動作する', () => {
+    const existing = new Set(['image'])
+    const result = deconflict('image', existing)
+    expect(result).toBe('image-1')
+  })
+
+  it('空のexistingの場合はそのまま返す', () => {
+    const existing = new Set<string>()
+    const result = deconflict('image.jpg', existing)
+    expect(result).toBe('image.jpg')
+  })
+})
+
+describe('makeFilename', () => {
+  const mockImage: ImageSnapshot = {
+    hash: 'abc123',
+    url: 'https://example.com/image.jpg',
+    width: 800,
+    height: 600,
+    alt: 'Sample Image',
+    context: 'Context text',
+    firstSeenAt: Date.now(),
+  }
+
+  const pageUrl = 'https://example.com/products/item'
+
+  it('デフォルトテンプレートで正しく生成される', () => {
+    const template = PRESET_TEMPLATES.default
+    const result = makeFilename(template, mockImage, 1, pageUrl)
+
+    // YYYY-MM-DD-example.com-800x600-001.jpg
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}-example.com-800x600-001\.jpg$/)
+  })
+
+  it('simpleテンプレートで正しく生成される', () => {
+    const template = PRESET_TEMPLATES.simple
+    const result = makeFilename(template, mockImage, 5, pageUrl)
+
+    expect(result).toBe('example.com-005.jpg')
+  })
+
+  it('detailedテンプレートで正しく生成される', () => {
+    const template = PRESET_TEMPLATES.detailed
+    const result = makeFilename(template, mockImage, 1, pageUrl)
+
+    // YYYY-MM-DD-HH-MM-SS-example.com-products-item-800x600-001.jpg
+    expect(result).toMatch(
+      /^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-example.com-products-item-800x600-001\.jpg$/
+    )
+  })
+
+  it('dimensionテンプレートで正しく生成される', () => {
+    const template = PRESET_TEMPLATES.dimension
+    const result = makeFilename(template, mockImage, 1, pageUrl)
+
+    expect(result).toBe('800x600-example.com-001.jpg')
+  })
+
+  it('altテンプレートで正しく生成される', () => {
+    const template = PRESET_TEMPLATES.alt
+    const result = makeFilename(template, mockImage, 1, pageUrl)
+
+    expect(result).toBe('Sample-Image-800x600-001.jpg')
+  })
+
+  it('altが存在しない場合は"noalt"になる', () => {
+    const imageNoAlt: ImageSnapshot = {
+      ...mockImage,
+      alt: undefined,
+    }
+
+    const template = PRESET_TEMPLATES.alt
+    const result = makeFilename(template, imageNoAlt, 1, pageUrl)
+
+    expect(result).toBe('noalt-800x600-001.jpg')
+  })
+
+  it('連番が3桁ゼロ埋めされる', () => {
+    const template = '{index}'
+    expect(makeFilename(template, mockImage, 1, pageUrl)).toMatch(/001\.jpg$/)
+    expect(makeFilename(template, mockImage, 10, pageUrl)).toMatch(/010\.jpg$/)
+    expect(makeFilename(template, mockImage, 100, pageUrl)).toMatch(/100\.jpg$/)
+  })
+
+  it('pathが正しく抽出される', () => {
+    const template = '{path}'
+    const result = makeFilename(template, mockImage, 1, 'https://example.com/products/item')
+    expect(result).toBe('products-item.jpg')
+  })
+
+  it('パスがルートの場合は"root"になる', () => {
+    const template = '{path}'
+    const result = makeFilename(template, mockImage, 1, 'https://example.com/')
+    expect(result).toBe('root.jpg')
+  })
+
+  it('不正なURLの場合はデフォルト値が使用される', () => {
+    const template = '{domain}-{path}'
+    const result = makeFilename(template, mockImage, 1, 'not-a-valid-url')
+    expect(result).toBe('unknown-root.jpg')
+  })
+
+  it('禁止文字を含むaltはサニタイズされる', () => {
+    const imageWithBadAlt: ImageSnapshot = {
+      ...mockImage,
+      alt: 'Image<>:"/\\|?*Name',
+    }
+
+    const template = '{alt}'
+    const result = makeFilename(template, imageWithBadAlt, 1, pageUrl)
+    expect(result).toBe('Image-Name.jpg')
+  })
+
+  it('data URLの画像は正しく拡張子が推測される', () => {
+    const imageWithDataUrl: ImageSnapshot = {
+      ...mockImage,
+      url: 'data:image/png;base64,iVBORw0KGgo...',
+    }
+
+    const template = '{index}'
+    const result = makeFilename(template, imageWithDataUrl, 1, pageUrl)
+    expect(result).toBe('001.png')
+  })
+})
+
+describe('getPresetTemplate', () => {
+  it('default プリセットを取得できる', () => {
+    const result = getPresetTemplate('default')
+    expect(result).toBe('{date}-{domain}-{w}x{h}-{index}')
+  })
+
+  it('simple プリセットを取得できる', () => {
+    const result = getPresetTemplate('simple')
+    expect(result).toBe('{domain}-{index}')
+  })
+
+  it('detailed プリセットを取得できる', () => {
+    const result = getPresetTemplate('detailed')
+    expect(result).toBe('{date}-{time}-{domain}-{path}-{w}x{h}-{index}')
+  })
+
+  it('dimension プリセットを取得できる', () => {
+    const result = getPresetTemplate('dimension')
+    expect(result).toBe('{w}x{h}-{domain}-{index}')
+  })
+
+  it('alt プリセットを取得できる', () => {
+    const result = getPresetTemplate('alt')
+    expect(result).toBe('{alt}-{w}x{h}-{index}')
+  })
+})

--- a/src/lib/filename.ts
+++ b/src/lib/filename.ts
@@ -1,0 +1,224 @@
+/**
+ * ファイル名生成ユーティリティ
+ *
+ * テンプレートベースのファイル名生成、サニタイズ、衝突回避を提供
+ *
+ * @module lib/filename
+ */
+
+import type { ImageSnapshot } from '../shared/types'
+
+/**
+ * プリセットテンプレート定義
+ */
+export const PRESET_TEMPLATES = {
+  default: '{date}-{domain}-{w}x{h}-{index}',
+  simple: '{domain}-{index}',
+  detailed: '{date}-{time}-{domain}-{path}-{w}x{h}-{index}',
+  dimension: '{w}x{h}-{domain}-{index}',
+  alt: '{alt}-{w}x{h}-{index}',
+} as const
+
+export type PresetTemplateName = keyof typeof PRESET_TEMPLATES
+
+/**
+ * テンプレート変数のコンテキスト
+ */
+export interface FilenameContext {
+  date: string
+  time: string
+  domain: string
+  path: string
+  w: number
+  h: number
+  alt: string
+  index: string
+}
+
+/**
+ * ファイル名サニタイズ（変数値用）
+ *
+ * 禁止文字を"-"に置換し、50文字以内に切り詰める
+ *
+ * @param text - サニタイズ対象のテキスト
+ * @param maxLength - 最大文字数（デフォルト: 50）
+ * @returns サニタイズ済みテキスト
+ */
+export const sanitize = (text: string, maxLength = 50): string => {
+  // 禁止文字と制御文字を"-"に置換
+  // eslint-disable-next-line no-control-regex
+  let sanitized = text.replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
+
+  // 連続する空白またはハイフンを単一ハイフンに
+  sanitized = sanitized.replace(/[\s-]+/g, '-')
+
+  // 先頭・末尾のハイフン削除
+  sanitized = sanitized.replace(/^-+|-+$/g, '')
+
+  // 最大長に切り詰め
+  if (maxLength > 0 && sanitized.length > maxLength) {
+    sanitized = sanitized.slice(0, maxLength)
+  }
+
+  // 空文字の場合はデフォルト名
+  if (!sanitized) {
+    sanitized = 'image'
+  }
+
+  return sanitized
+}
+
+/**
+ * URLから拡張子を推測
+ *
+ * @param url - 画像URL
+ * @returns 拡張子（ドット含まない、例: "jpg", "png"）
+ */
+export const guessExtension = (url: string): string => {
+  // data URLの場合
+  if (url.startsWith('data:')) {
+    const match = url.match(/^data:image\/([a-z]+);/)
+    if (match?.[1]) {
+      const mime = match[1]
+      // MIME to extension mapping
+      const mimeMap: Record<string, string> = {
+        jpeg: 'jpg',
+        png: 'png',
+        gif: 'gif',
+        webp: 'webp',
+        svg: 'svg',
+        bmp: 'bmp',
+      }
+      return mimeMap[mime] ?? 'jpg'
+    }
+    return 'jpg'
+  }
+
+  // 通常URLの場合
+  try {
+    const urlObj = new URL(url)
+    const pathname = urlObj.pathname
+    const match = pathname.match(/\.([a-z0-9]+)$/i)
+    if (match?.[1]) {
+      const ext = match[1].toLowerCase()
+      // 画像拡張子かチェック
+      const validExts = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'ico']
+      if (validExts.includes(ext)) {
+        return ext === 'jpeg' ? 'jpg' : ext
+      }
+    }
+  } catch {
+    // URLパース失敗時
+  }
+
+  // デフォルト
+  return 'jpg'
+}
+
+/**
+ * 衝突回避
+ *
+ * 既存のファイル名セットと照合し、重複しない名前を生成
+ *
+ * @param name - 元のファイル名（拡張子含む）
+ * @param existing - 既存のファイル名セット
+ * @returns 衝突しないファイル名
+ */
+export const deconflict = (name: string, existing: Set<string>): string => {
+  if (!existing.has(name)) {
+    return name
+  }
+
+  // 拡張子とベース名に分割
+  const lastDotIndex = name.lastIndexOf('.')
+  let base: string
+  let ext: string
+
+  if (lastDotIndex > 0) {
+    base = name.slice(0, lastDotIndex)
+    ext = name.slice(lastDotIndex)
+  } else {
+    base = name
+    ext = ''
+  }
+
+  // カウンターを増やしながら衝突しない名前を探す
+  let counter = 1
+  let candidate = `${base}-${counter}${ext}`
+
+  while (existing.has(candidate)) {
+    counter++
+    candidate = `${base}-${counter}${ext}`
+  }
+
+  return candidate
+}
+
+/**
+ * テンプレート文字列を評価してファイル名を生成
+ *
+ * @param template - テンプレート文字列（例: "{date}-{domain}-{index}"）
+ * @param image - 画像スナップショット
+ * @param index - 連番（1始まり）
+ * @param pageUrl - ページURL（domainとpath抽出用）
+ * @returns 生成されたファイル名（拡張子含む）
+ */
+export const makeFilename = (
+  template: string,
+  image: ImageSnapshot,
+  index: number,
+  pageUrl: string
+): string => {
+  const now = new Date()
+
+  // URLからdomain, path抽出
+  let domain = 'unknown'
+  let path = ''
+  try {
+    const url = new URL(pageUrl)
+    domain = url.hostname
+    path = url.pathname
+      .split('/')
+      .filter(Boolean)
+      .join('-')
+  } catch {
+    // URLパース失敗時
+  }
+
+  // テンプレート変数の値を準備
+  const context: FilenameContext = {
+    date: now.toISOString().split('T')[0] ?? '', // YYYY-MM-DD
+    time: now.toTimeString().split(' ')[0]?.replace(/:/g, '-') ?? '', // HH-MM-SS
+    domain,
+    path: path || 'root',
+    w: image.width,
+    h: image.height,
+    alt: image.alt ? sanitize(image.alt) : 'noalt',
+    index: String(index).padStart(3, '0'), // 001, 002, ...
+  }
+
+  // テンプレート変数を置換
+  let filename = template
+  for (const [key, value] of Object.entries(context)) {
+    const placeholder = `{${key}}`
+    filename = filename.replace(new RegExp(placeholder.replace(/[{}]/g, '\\$&'), 'g'), String(value))
+  }
+
+  // 最終的なファイル名全体をサニタイズ（長さ制限なし）
+  filename = sanitize(filename, 0)
+
+  // 拡張子を付与
+  const ext = guessExtension(image.url)
+
+  return `${filename}.${ext}`
+}
+
+/**
+ * プリセットテンプレート名から実際のテンプレート文字列を取得
+ *
+ * @param presetName - プリセット名
+ * @returns テンプレート文字列
+ */
+export const getPresetTemplate = (presetName: PresetTemplateName): string => {
+  return PRESET_TEMPLATES[presetName]
+}


### PR DESCRIPTION
## 概要

Issue #20のファイル名生成機能を実装しました。テンプレートベースのファイル名生成、サニタイズ、衝突回避機能を提供します。

## 実装内容

### lib/filename.ts
- `sanitize()`: 禁止文字の置換とサニタイズ（50文字制限オプション）
- `guessExtension()`: URLから拡張子を推測（data URL対応）
- `deconflict()`: ファイル名衝突を回避
- `makeFilename()`: テンプレートベースのファイル名生成
- `getPresetTemplate()`: プリセットテンプレート取得

### プリセットテンプレート5種
- `default`: `{date}-{domain}-{w}x{h}-{index}`
- `simple`: `{domain}-{index}`
- `detailed`: `{date}-{time}-{domain}-{path}-{w}x{h}-{index}`
- `dimension`: `{w}x{h}-{domain}-{index}`
- `alt`: `{alt}-{w}x{h}-{index}`

### テンプレート変数8種
- `{date}`: YYYY-MM-DD形式の日付
- `{time}`: HH-MM-SS形式の時刻
- `{domain}`: ホスト名
- `{path}`: パス（スラッシュをハイフンに変換）
- `{w}`: 画像の幅
- `{h}`: 画像の高さ
- `{alt}`: altテキスト（サニタイズ済み）
- `{index}`: 3桁ゼロ埋めの連番

### テスト
- 包括的なユニットテスト40件
- 全テストパス
- TypeScript strict mode対応
- ESLint/Prettierチェック通過

## 成功基準

- [x] 全プリセットテンプレート動作確認
- [x] 衝突回避ロジック確認
- [x] 禁止文字サニタイズ確認

## テスト結果

```
✓ src/lib/filename.test.ts  (40 tests) 35ms
  Test Files  1 passed (1)
  Tests      40 passed (40)
```

## 関連Issue

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)